### PR TITLE
Filter Google search results to news pages

### DIFF
--- a/app/services/news_service.py
+++ b/app/services/news_service.py
@@ -680,7 +680,13 @@ class NewsService:
                 google_items: List[Dict[str, Any]] = []
                 # Limit number of calls to keep performance reasonable
                 for q in queries[:3]:
-                    items = await self.google_search.search(q, num=10, lang_nl=True, site_nl_only=False)
+                    items = await self.google_search.search(
+                        q,
+                        num=10,
+                        lang_nl=True,
+                        site_nl_only=False,
+                        news_only=True,
+                    )
                     if items:
                         google_items.extend(items)
 
@@ -749,7 +755,13 @@ class NewsService:
 
                     google_items: List[Dict[str, Any]] = []
                     for q in queries:
-                        items = await self.google_search.search(q, num=10, lang_nl=True, site_nl_only=True)
+                        items = await self.google_search.search(
+                            q,
+                            num=10,
+                            lang_nl=True,
+                            site_nl_only=True,
+                            news_only=True,
+                        )
                         if items:
                             google_items.extend(items)
 

--- a/tests/test_services/test_google_search.py
+++ b/tests/test_services/test_google_search.py
@@ -1,0 +1,56 @@
+import pytest
+
+from app.services import google_search
+from app.services.google_search import GoogleSearchClient
+
+
+def test_is_probable_news_url():
+    assert GoogleSearchClient._is_probable_news_url(
+        "https://nos.nl/2024/05/05/nieuws/test.html"
+    )
+    assert not GoogleSearchClient._is_probable_news_url(
+        "https://example.com/about"
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_filters_news_urls(monkeypatch):
+    sample_data = {
+        "items": [
+            {"link": "https://example.com/about", "title": "About"},
+            {
+                "link": "https://nos.nl/2024/05/05/nieuws/test.html",
+                "title": "Nieuws",
+            },
+        ]
+    }
+
+    class DummyResponse:
+        status_code = 200
+
+        def json(self):
+            return sample_data
+
+    class DummyAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def get(self, *args, **kwargs):
+            return DummyResponse()
+
+    monkeypatch.setattr(google_search.httpx, "AsyncClient", DummyAsyncClient)
+    monkeypatch.setattr(google_search.settings, "GOOGLE_SEARCH_API_KEY", "k")
+    monkeypatch.setattr(google_search.settings, "GOOGLE_SEARCH_ENGINE_ID", "cx")
+    monkeypatch.setattr(google_search.settings, "EXTERNAL_SERVICE_TIMEOUT", 5)
+
+    client = GoogleSearchClient()
+    results = await client.search("test", news_only=True)
+
+    assert len(results) == 1
+    assert results[0]["url"] == "https://nos.nl/2024/05/05/nieuws/test.html"


### PR DESCRIPTION
## Summary
- add `news_only` option and heuristics to GoogleSearchClient to keep only likely news URLs
- use news-only filtering when enriching results via Google search
- cover new URL filtering behavior with unit tests

## Testing
- `pytest tests/test_services/test_google_search.py`

------
https://chatgpt.com/codex/tasks/task_e_68bddb669f508330a3a1fc99b2622832