### PR TITLE
fix: handle NewsArticle objects in risk assessment

### DIFF
--- a/app/services/risk_service.py
+++ b/app/services/risk_service.py
@@ -2,7 +2,7 @@
 Risk assessment service for integrated company analysis.
 """
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
@@ -328,9 +328,19 @@ class RiskService:
             ]
 
             for article in news.articles[:20]:  # Check recent articles
-                article_text = (
-                    article.get("title", "") + " " + article.get("summary", "")
-                ).lower()
+                # News articles may be dictionaries or pydantic models.
+                # Support both structures when extracting text for keyword checks.
+                title = (
+                    article.get("title", "")
+                    if isinstance(article, dict)
+                    else getattr(article, "title", "")
+                )
+                summary = (
+                    article.get("summary", "")
+                    if isinstance(article, dict)
+                    else getattr(article, "summary", "")
+                )
+                article_text = (title + " " + summary).lower()
 
                 for keyword in financial_risk_keywords:
                     if keyword in article_text:


### PR DESCRIPTION
## Summary
- handle NewsArticle objects and dicts in financial risk keyword scan

## Testing
- `black app/services/risk_service.py`
- `isort --check-only app/ tests/` *(fails: imports are incorrectly sorted in many files)*
- `flake8 app/services/risk_service.py` *(fails: line-too-long and bare except errors)*
- `mypy app/services/risk_service.py` *(fails: multiple typing errors)*
- `pytest` *(fails: missing modules during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bde5f3c7648330b4ca11eb5386de86