### PR TITLE
Ensure simple news analysis processes Google Search results

### DIFF
--- a/app/services/news_service.py
+++ b/app/services/news_service.py
@@ -538,7 +538,8 @@ class NewsService:
 
             # Quick analysis without deep content processing
             analyzed_articles = []
-            for article in articles[:max_results]:  # Limit processing
+            # Analyze all gathered articles to also include Google Search results
+            for article in articles:
                 analyzed_article = await self._analyze_article(article, company_name)
                 if (
                     analyzed_article and analyzed_article.relevance_score >= 0.2


### PR DESCRIPTION
## Summary
- Process all articles in simple news analysis so Google Search enrichment is included

## Testing
- `OPENAI_API_KEY=sk-test ENABLE_NEWS_SERVICE=False pytest` *(fails: ModuleNotFoundError: No module named 'app.services.kvk_service')*

------
https://chatgpt.com/codex/tasks/task_e_68bdfe14d37483308371c04bd791c476