### PR TITLE
feat: add rechtspraak harvester and search

### DIFF
--- a/tests/fixtures/legal/ecli_content.xml
+++ b/tests/fixtures/legal/ecli_content.xml
@@ -1,0 +1,15 @@
+<root xmlns:dcterms="http://purl.org/dc/terms/" xmlns:psi="http://psi.rechtspraak.nl/">
+  <dcterms:identifier>ECLI:NL:TEST:2024:1</dcterms:identifier>
+  <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">Testbedrijf B.V. tegen Gemeente</dc:title>
+  <dcterms:creator resourceIdentifier="inst1">Rechtbank Teststad</dcterms:creator>
+  <dcterms:issued>2024-01-15</dcterms:issued>
+  <dcterms:subject resourceIdentifier="rg1">Civiel recht</dcterms:subject>
+  <psi:procedure>Civiele procedure</psi:procedure>
+  <psi:zaaknummer>1234/2024</psi:zaaknummer>
+  <inhoudsindicatie>
+    <p>Testbedrijf B.V. krijgt boete van de Kamer van Koophandel (KvK 12345678).</p>
+  </inhoudsindicatie>
+  <uitspraak>
+    <p>Dit is de volledige tekst van de uitspraak over Testbedrijf B.V.</p>
+  </uitspraak>
+</root>

--- a/tests/fixtures/legal/feed_empty.xml
+++ b/tests/fixtures/legal/feed_empty.xml
@@ -1,0 +1,1 @@
+<feed xmlns="http://www.w3.org/2005/Atom"></feed>

--- a/tests/fixtures/legal/feed_page1.xml
+++ b/tests/fixtures/legal/feed_page1.xml
@@ -1,0 +1,6 @@
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>ECLI:NL:TEST:1</id>
+    <updated>2024-02-01T10:00:00Z</updated>
+  </entry>
+</feed>

--- a/tests/fixtures/legal/feed_page2_deleted.xml
+++ b/tests/fixtures/legal/feed_page2_deleted.xml
@@ -1,0 +1,6 @@
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry deleted="ecli">
+    <id>ECLI:NL:TEST:2</id>
+    <updated>2024-02-01T11:00:00Z</updated>
+  </entry>
+</feed>

--- a/tests/test_services/test_legal_service.py
+++ b/tests/test_services/test_legal_service.py
@@ -1,467 +1,121 @@
-"""
-Tests for Legal Service.
-"""
+"""Tests for the Rechtspraak legal service."""
 
-import pytest
-from unittest.mock import AsyncMock, Mock, patch
-import httpx
 from datetime import datetime
-from bs4 import BeautifulSoup
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
-from app.services.legal_service import LegalService
-from app.models.response_models import LegalCase
-from app.utils.text_utils import normalize_company_name, calculate_similarity, match_company_variations
-from app.utils.web_utils import is_path_allowed, get_crawl_delay
+import httpx
+import pytest
+
+from app.services.legal_service import (
+    LegalService,
+    _extract_kvk_numbers,
+)
 
 
-@pytest.fixture
-def legal_service():
-    """Create Legal service instance for testing."""
-    with patch('app.services.legal_service.settings') as mock_settings:
-        mock_settings.APP_NAME = "test-app"
-        mock_settings.RECHTSPRAAK_TIMEOUT = 30
-        service = LegalService()
-        service.robots_allowed = True  # Skip robots.txt check for tests
-        return service
+FIXTURES = Path("tests/fixtures/legal")
 
 
 @pytest.fixture
-def mock_search_html():
-    """Sample HTML from rechtspraak.nl search results."""
-    return """
-    <html>
-    <body>
-        <div class="search-results">
-            <div class="search-result">
-                <h3><a href="/Uitspraken/12345">Test Company B.V. tegen gemeente Amsterdam</a></h3>
-                <p class="datum">15-03-2023</p>
-                <p class="rechtbank">Rechtbank Amsterdam</p>
-                <p class="samenvatting">Geschil betreffende bouwvergunning...</p>
-            </div>
-            <div class="search-result">
-                <h3><a href="/Uitspraken/67890">Stichting X tegen Test Company B.V.</a></h3>
-                <p class="datum">22-01-2023</p>
-                <p class="rechtbank">Gerechtshof Den Haag</p>
-                <p class="samenvatting">Contractgeschil aangaande leveringsvoorwaarden...</p>
-            </div>
-        </div>
-    </body>
-    </html>
-    """
+def service() -> LegalService:
+    return LegalService(rate_limit=1000)  # effectively disable waits in tests
 
 
 @pytest.fixture
-def mock_case_detail_html():
-    """Sample HTML from a rechtspraak.nl case detail page."""
-    return """
-    <html>
-    <body>
-        <div class="uitspraak-header">
-            <h1>Rechtbank Amsterdam</h1>
-            <p>ECLI:NL:RBAMS:2023:1234</p>
-            <p>Zaaknummer: 12345/2023</p>
-        </div>
-        <div class="partijen">
-            <p>Eisers: Test Company B.V.</p>
-            <p>Verweerder: Gemeente Amsterdam</p>
-        </div>
-        <div class="uitspraak-content">
-            <p>De rechtbank oordeelt als volgt...</p>
-            <p>Test Company B.V. heeft onvoldoende bewijs geleverd...</p>
-            <p>Het verzoek wordt afgewezen.</p>
-        </div>
-    </body>
-    </html>
-    """
+def sample_doc(service: LegalService):
+    xml = (FIXTURES / "ecli_content.xml").read_text(encoding="utf-8")
+    return service._parse_ecli_content(xml)
 
 
-@pytest.fixture
-def sample_robots_txt():
-    """Sample robots.txt content."""
-    return """
-User-agent: *
-Allow: /Uitspraken/
-Disallow: /admin/
-Disallow: /private/
-Crawl-delay: 1
-
-User-agent: test-bot
-Disallow: /
-    """
+# ---------------------------------------------------------------------------
+# Parser and KvK extraction
+# ---------------------------------------------------------------------------
 
 
-class TestLegalService:
-    """Test cases for LegalService."""
+def test_parse_ecli_content(sample_doc):
+    assert sample_doc["ecli"] == "ECLI:NL:TEST:2024:1"
+    assert sample_doc["title"].startswith("Testbedrijf")
+    assert sample_doc["instantie"]["name"] == "Rechtbank Teststad"
+    assert sample_doc["rechtsgebieden"][0]["label"] == "Civiel recht"
+    assert sample_doc["zaaknummers"] == ["1234/2024"]
+    assert "<p>" not in sample_doc["inhoudsindicatie_text"]
+    assert sample_doc["kvk_numbers"] == ["12345678"]
 
-    @pytest.mark.asyncio
-    async def test_initialization(self, legal_service):
-        """Test service initialization."""
-        assert legal_service.base_url == "https://www.rechtspraak.nl"
-        assert legal_service.rate_limit_delay == 1.0
-        assert legal_service.robots_allowed is True
 
-    @pytest.mark.asyncio
-    async def test_robots_compliance_check(self, legal_service):
-        """Test robots.txt compliance checking."""
-        with patch('httpx.AsyncClient') as mock_client:
-            mock_response = Mock()
-            mock_response.status_code = 200
-            mock_response.text = """
-User-agent: *
-Allow: /Uitspraken/
-Crawl-delay: 2
-            """
-            
-            mock_client.return_value.__aenter__.return_value.get.return_value = mock_response
-            
-            await legal_service._check_robots_compliance()
-            
-            assert legal_service.robots_allowed is True
-            assert legal_service.crawl_delay == 2.0
+def test_extract_kvk_numbers():
+    text = "KvK: 12345678 en ook kamer van koophandel 87654321."  # two numbers
+    assert sorted(_extract_kvk_numbers(text)) == ["12345678", "87654321"]
+    assert _extract_kvk_numbers("geen nummers") == []
 
-    @pytest.mark.asyncio
-    async def test_cache_functionality(self, legal_service):
-        """Test caching mechanism."""
-        # Test cache miss
-        cache_key = legal_service._get_cache_key("Test Company", "Test Trade")
-        cached_result = legal_service._get_from_cache(cache_key)
-        assert cached_result is None
-        
-        # Test cache set and hit
-        test_data = [{"test": "data"}]
-        legal_service._set_cache(cache_key, test_data, 3600)
-        cached_result = legal_service._get_from_cache(cache_key)
-        assert cached_result == test_data
 
-    @pytest.mark.asyncio
-    async def test_search_company_cases_cached(self, legal_service):
-        """Test search with cached results."""
-        test_cases = [
-            LegalCase(
-                ecli="ECLI:NL:RBAMS:2023:1234",
-                case_number="12345/2023",
-                date=datetime(2023, 3, 15),
-                court="Rechtbank Amsterdam",
-                type="civil",
-                parties=["Test Company B.V."],
-                summary="Test case summary",
-                outcome="unknown",
-                url="https://www.rechtspraak.nl/Uitspraken/12345",
-                relevance_score=0.9
-            )
-        ]
-        
-        # Set up cache
-        cache_key = legal_service._get_cache_key("Test Company B.V.")
-        legal_service._set_cache(cache_key, test_cases, 3600)
-        
-        # Test cached retrieval
-        results = await legal_service.search_company_cases("Test Company B.V.")
-        assert len(results) == 1
-        assert results[0].ecli == "ECLI:NL:RBAMS:2023:1234"
+# ---------------------------------------------------------------------------
+# Search
+# ---------------------------------------------------------------------------
 
-    @pytest.mark.asyncio
-    async def test_search_company_cases_no_robots(self, legal_service):
-        """Test search when robots.txt disallows."""
-        legal_service.robots_allowed = False
-        
-        results = await legal_service.search_company_cases("Test Company")
-        assert results == []
 
-    @pytest.mark.asyncio
-    async def test_fetch_search_page(self, legal_service, mock_search_html):
-        """Test fetching search page HTML."""
-        with patch('httpx.AsyncClient') as mock_client:
-            mock_response = Mock()
-            mock_response.status_code = 200
-            mock_response.text = mock_search_html
-            
-            mock_client.return_value.__aenter__.return_value.get.return_value = mock_response
-            
-            result = await legal_service._fetch_search_page({'q': 'Test Company'})
-            assert result == mock_search_html
-
-    @pytest.mark.asyncio
-    async def test_fetch_search_page_error(self, legal_service):
-        """Test handling of search page fetch errors."""
-        with patch('httpx.AsyncClient') as mock_client:
-            mock_response = Mock()
-            mock_response.status_code = 500
-            
-            mock_client.return_value.__aenter__.return_value.get.return_value = mock_response
-            
-            result = await legal_service._fetch_search_page({'q': 'Test Company'})
-            assert result == ""
-
-    def test_parse_search_results(self, legal_service, mock_search_html):
-        """Test parsing search results HTML."""
-        results = legal_service._parse_search_results(mock_search_html)
-        
-        assert len(results) == 2
-        assert "Test Company B.V." in results[0]['title']
-        assert "/Uitspraken/12345" in results[0]['url']
-        assert "15-03-2023" in results[0]['date_text']
-        assert "Rechtbank Amsterdam" in results[0]['court_text']
-
-    def test_parse_search_results_empty(self, legal_service):
-        """Test parsing empty search results."""
-        empty_html = "<html><body>No results found</body></html>"
-        results = legal_service._parse_search_results(empty_html)
-        assert results == []
-
-    def test_extract_case_from_element(self, legal_service):
-        """Test extracting case information from HTML element."""
-        html = """
-        <div class="search-result">
-            <h3><a href="/Uitspraken/12345">Test Company B.V. vs City</a></h3>
-            <p>12-03-2023</p>
-            <p>Rechtbank Amsterdam</p>
-            <p class="summary">Contract dispute case</p>
-        </div>
-        """
-        
-        soup = BeautifulSoup(html, 'html.parser')
-        element = soup.find('div', class_='search-result')
-        
-        result = legal_service._extract_case_from_element(element)
-        
-        assert result is not None
-        assert "/Uitspraken/12345" in result['url']
-        assert "Test Company B.V." in result['title']
-
-    @pytest.mark.asyncio
-    async def test_get_case_details(self, legal_service, mock_case_detail_html):
-        """Test fetching case details."""
-        with patch('httpx.AsyncClient') as mock_client:
-            mock_response = Mock()
-            mock_response.status_code = 200
-            mock_response.text = mock_case_detail_html
-            
-            mock_client.return_value.__aenter__.return_value.get.return_value = mock_response
-            
-            result = await legal_service.get_case_details("https://www.rechtspraak.nl/Uitspraken/12345")
-            
-            assert result is not None
-            assert result['ecli'] == "ECLI:NL:RBAMS:2023:1234"
-            assert result['case_number'] == "12345/2023"
-            assert "Test Company B.V." in result['parties']
-
-    def test_parse_case_detail(self, legal_service, mock_case_detail_html):
-        """Test parsing case detail HTML."""
-        result = legal_service._parse_case_detail(
-            mock_case_detail_html, 
-            "https://www.rechtspraak.nl/Uitspraken/12345"
-        )
-        
-        assert result['ecli'] == "ECLI:NL:RBAMS:2023:1234"
-        assert result['case_number'] == "12345/2023"
-        assert len(result['parties']) > 0
-
-    def test_deduplicate_cases(self, legal_service):
-        """Test case deduplication."""
-        cases = [
-            {'url': 'https://example.com/case1', 'ecli': 'ECLI:NL:TEST:2023:001'},
-            {'url': 'https://example.com/case1', 'ecli': 'ECLI:NL:TEST:2023:001'},  # Duplicate URL
-            {'url': 'https://example.com/case2', 'ecli': 'ECLI:NL:TEST:2023:002'},
-        ]
-        
-        unique_cases = legal_service._deduplicate_cases(cases)
-        assert len(unique_cases) == 2
-
-    def test_calculate_relevance_score(self, legal_service):
-        """Test relevance score calculation."""
-        case_data = {
-            'title': 'Test Company B.V. tegen gemeente',
-            'summary': 'Geschil over bouwvergunning voor Test Company B.V.',
-            'parties': ['Test Company B.V.', 'Gemeente Amsterdam']
+def test_search_by_company(service: LegalService, sample_doc):
+    service.index.upsert(sample_doc)
+    # Add a second unrelated document
+    service.index.upsert(
+        {
+            "ecli": "ECLI:NL:TEST:2024:2",
+            "title": "Andere partij",
+            "date": datetime(2024, 1, 20),
+            "instantie": {"name": "Rechtbank X", "id": "inst2"},
+            "rechtsgebieden": [],
+            "zaaknummers": [],
+            "kvk_numbers": [],
+            "inhoudsindicatie_text": "",
+            "full_text": "",
+            "deeplink": "http://deeplink.rechtspraak.nl/uitspraak?id=ECLI:NL:TEST:2024:2",
         }
-        
-        score = legal_service._calculate_relevance_score(case_data, "Test Company B.V.")
-        assert score >= 0.8  # Should be high relevance
+    )
 
-    def test_calculate_relevance_score_low(self, legal_service):
-        """Test low relevance score calculation."""
-        case_data = {
-            'title': 'Unrelated Company vs Another Party',
-            'summary': 'Case about something unrelated',
-            'parties': ['Other Company B.V.', 'Different Party']
-        }
-        
-        score = legal_service._calculate_relevance_score(case_data, "Test Company B.V.")
-        assert score < 0.6  # Should be low relevance
+    res = service.search_by_company("Testbedrijf")
+    assert len(res) == 1
+    assert res[0].ecli == "ECLI:NL:TEST:2024:1"
 
-    def test_convert_to_legal_case(self, legal_service):
-        """Test converting case data to LegalCase object."""
-        case_data = {
-            'url': 'https://www.rechtspraak.nl/Uitspraken/12345',
-            'title': 'Test Company B.V. vs City',
-            'date_text': '15-03-2023',
-            'court_text': 'Rechtbank Amsterdam',
-            'summary': 'Contract dispute case',
-            'ecli': 'ECLI:NL:RBAMS:2023:1234',
-            'case_number': '12345/2023',
-            'parties': ['Test Company B.V.', 'City of Amsterdam']
-        }
-        
-        legal_case = legal_service._convert_to_legal_case(case_data, 0.9)
-        
-        assert legal_case is not None
-        assert legal_case.ecli == 'ECLI:NL:RBAMS:2023:1234'
-        assert legal_case.case_number == '12345/2023'
-        assert legal_case.court == 'Rechtbank Amsterdam'
-        assert legal_case.relevance_score == 0.9
+    # fuzzy search (missing character)
+    res = service.search_by_company("Testbedrij")
+    assert res and res[0].ecli == "ECLI:NL:TEST:2024:1"
 
-    def test_convert_to_legal_case_no_ecli(self, legal_service):
-        """Test converting case data without ECLI."""
-        case_data = {
-            'url': 'https://www.rechtspraak.nl/Uitspraken/12345',
-            'title': 'Test Company B.V. vs City',
-            'date_text': '15-03-2023',
-            'court_text': 'Rechtbank Amsterdam',
-            'summary': 'Contract dispute case',
-            'case_number': '12345/2023',
-            'parties': ['Test Company B.V.']
-        }
-        
-        legal_case = legal_service._convert_to_legal_case(case_data, 0.8)
-        
-        assert legal_case is not None
-        assert legal_case.ecli.startswith('ECLI:NL:PLACEHOLDER:')
-        assert legal_case.case_number == '12345/2023'
-
-    def test_determine_case_type(self, legal_service):
-        """Test case type determination."""
-        # Criminal case
-        criminal_case = {
-            'title': 'Strafzaak tegen verdachte',
-            'summary': 'Strafrecht procedure',
-            'court_text': 'Rechtbank'
-        }
-        assert legal_service._determine_case_type(criminal_case) == 'criminal'
-        
-        # Administrative case
-        admin_case = {
-            'title': 'Bestuursrecht zaak',
-            'summary': 'Geschil met gemeente',
-            'court_text': 'Rechtbank'
-        }
-        assert legal_service._determine_case_type(admin_case) == 'administrative'
-        
-        # Civil case (default)
-        civil_case = {
-            'title': 'Contract geschil',
-            'summary': 'Burgerlijk recht',
-            'court_text': 'Rechtbank'
-        }
-        assert legal_service._determine_case_type(civil_case) == 'civil'
-
-    def test_assess_legal_risk_no_cases(self, legal_service):
-        """Test risk assessment with no cases."""
-        risk_level = legal_service.assess_legal_risk([])
-        assert risk_level == 'low'
-
-    def test_assess_legal_risk_low(self, legal_service):
-        """Test low risk assessment."""
-        cases = [
-            LegalCase(
-                ecli="ECLI:NL:RBAMS:2020:1234",
-                case_number="12345/2020",
-                date=datetime(2020, 3, 15),  # Old case
-                court="Rechtbank Amsterdam",
-                type="civil",
-                parties=["Test Company B.V."],
-                summary="Old civil case",
-                outcome="won",
-                url="https://www.rechtspraak.nl/Uitspraken/12345",
-                relevance_score=0.8
-            )
-        ]
-        
-        risk_level = legal_service.assess_legal_risk(cases)
-        assert risk_level == 'low'
-
-    def test_assess_legal_risk_high(self, legal_service):
-        """Test high risk assessment."""
-        cases = []
-        # Create multiple recent criminal cases
-        for i in range(3):
-            case = LegalCase(
-                ecli=f"ECLI:NL:RBAMS:2023:{1234+i}",
-                case_number=f"{12345+i}/2023",
-                date=datetime(2023, 3, 15),  # Recent
-                court="Rechtbank Amsterdam",
-                type="criminal",  # Criminal type
-                parties=["Test Company B.V."],
-                summary=f"Criminal case {i+1}",
-                outcome="lost",
-                url=f"https://www.rechtspraak.nl/Uitspraken/{12345+i}",
-                relevance_score=0.9
-            )
-            cases.append(case)
-        
-        risk_level = legal_service.assess_legal_risk(cases)
-        assert risk_level == 'high'
-
-    @pytest.mark.asyncio
-    async def test_rate_limiting(self, legal_service):
-        """Test rate limiting enforcement."""
-        import time
-        
-        start_time = time.time()
-        legal_service.last_request_time = start_time
-        
-        await legal_service._enforce_rate_limit()
-        await legal_service._enforce_rate_limit()
-        
-        elapsed = time.time() - start_time
-        assert elapsed >= legal_service.crawl_delay
+    # date filter excluding the document
+    res = service.search_by_company("Testbedrijf", date_from=datetime(2025, 1, 1))
+    assert res == []
 
 
-class TestTextUtils:
-    """Test cases for text utility functions."""
-
-    def test_normalize_company_name(self):
-        """Test company name normalization."""
-        assert normalize_company_name("Test Company B.V.") == "test company bv"
-        assert normalize_company_name("Besloten Vennootschap Test") == "bv test"
-        assert normalize_company_name("De Test Company N.V.") == "test company nv"
-
-    def test_calculate_similarity(self):
-        """Test similarity calculation."""
-        assert calculate_similarity("Test Company B.V.", "Test Company BV") > 0.9
-        assert calculate_similarity("Test Company", "Different Company") < 0.5
-        assert calculate_similarity("", "Test") == 0.0
-
-    def test_match_company_variations(self):
-        """Test company name variation matching."""
-        text = "In deze zaak tussen Test Company B.V. en de gemeente..."
-        assert match_company_variations(text, "Test Company B.V.") is True
-        assert match_company_variations(text, "Different Company") is False
-        assert match_company_variations(text, "Test Company") is True  # Partial match
+def test_search_by_kvk(service: LegalService, sample_doc):
+    service.index.upsert(sample_doc)
+    res = service.search_by_kvk("12345678")
+    assert len(res) == 1
+    assert res[0].title.startswith("Testbedrijf")
 
 
-class TestWebUtils:
-    """Test cases for web utility functions."""
+# ---------------------------------------------------------------------------
+# Harvester
+# ---------------------------------------------------------------------------
 
-    def test_is_path_allowed(self):
-        """Test robots.txt path checking."""
-        robots_txt = """
-User-agent: *
-Allow: /Uitspraken/
-Disallow: /admin/
-        """
-        
-        assert is_path_allowed("/Uitspraken/12345", "*", robots_txt) is True
-        assert is_path_allowed("/admin/secret", "*", robots_txt) is False
-        assert is_path_allowed("/public/page", "*", robots_txt) is True  # Not disallowed
 
-    def test_get_crawl_delay(self):
-        """Test crawl delay extraction."""
-        robots_txt = """
-User-agent: *
-Crawl-delay: 2
-        """
-        
-        assert get_crawl_delay(robots_txt, "*") == 2
-        assert get_crawl_delay(robots_txt, "test-bot") == 2  # Falls back to *
-        assert get_crawl_delay("", "*") is None
+@pytest.mark.asyncio
+async def test_harvest_pagination_and_delete(service: LegalService, sample_doc):
+    feed1 = (FIXTURES / "feed_page1.xml").read_text(encoding="utf-8")
+    feed2 = (FIXTURES / "feed_page2_deleted.xml").read_text(encoding="utf-8")
+    feed3 = (FIXTURES / "feed_empty.xml").read_text(encoding="utf-8")
+
+    # Sequence of responses for search requests
+    search_responses = [
+        httpx.Response(200, text=feed1),
+        httpx.Response(200, text=feed2),
+        httpx.Response(200, text=feed3),
+    ]
+
+    with patch.object(
+        service, "_http_get", new_callable=AsyncMock, side_effect=search_responses
+    ):
+        service.fetch_ecli_content = AsyncMock(return_value=sample_doc)
+        result = await service.harvest(modified="2024-02-01", max=1)
+
+    assert result == {"upserts": 1, "deletes": 1, "pages": 2}
+    assert sample_doc["ecli"] in service.index.docs
+    assert "ECLI:NL:TEST:2" not in service.index.docs
+


### PR DESCRIPTION
## Summary
- add pluggable in-memory search index for Rechtspraak data
- implement harvester with pagination and delete handling
- support company name and KvK lookups with fuzzy filtering

## Testing
- `OPENAI_API_KEY=sk-test ENABLE_NEWS_SERVICE=false pytest tests/test_services/test_legal_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bed47953bc8330be4143029d7bc3d9